### PR TITLE
fix markdown table formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,10 +560,7 @@ The following global parameters are available.
 
 | Name | Type | Required | Description |
 | ---- | ---- |:--------:| ----------- |
-| client_id | str |  | The unique identifier for the client application
-This is used to track the client application and its usage
-(UUID, serial number, or other number unique per device)
- |
+| client_id | str |  | The unique identifier for the client application<br> This is used to track the client application and its usage<br> (UUID, serial number, or other number unique per device) |
 | client_name | str |  | The client_name parameter. |
 | client_version | str |  | The client_version parameter. |
 | client_platform | str |  | The client_platform parameter. |


### PR DESCRIPTION
humbly I come to you with a patch to fix this markdown table's formatting so it renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved the readability of the `client_id` parameter description in the global parameters table by consolidating it into a single line with HTML line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->